### PR TITLE
FR - Multiple files for compose

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,16 +30,17 @@ Usage
 
 .. code-block:: bash
 
-    usage: ecs_composex [-h] {up,config,version,init} ...
+    usage: ecs-composex [-h] {up,render,config,init,version} ...
 
     positional arguments:
-      {up,config,version,init}
-                            Command to execute.
+      {up,render,config,init,version}
+
         up                  Generates & Validates the CFN templates,
                             Creates/Updates stack in CFN
-        config              Generates & Validates the CFN templates locally. No
-                            upload to S3.
-        version             ECS ComposeX Version
+        render              Generates & Validates the CFN templates locally. No
+                            upload to S3
+        config              Merges docker-compose files to provide with the final
+                            compose content version
         init                Initializes your AWS Account with prerequisites
                             settings for ECS
         version             ECS ComposeX Version
@@ -48,21 +49,23 @@ Usage
       -h, --help            show this help message and exit
 
     Command 'up'
-    usage: ecs_composex up [-h] -n NAME -f DOCKERCOMPOSEXFILE [-d OUTPUTDIRECTORY]
-                           [--format {json,yaml,text}] [--region REGIONNAME]
-                           [--az ZONES] [-b BUCKETNAME] [--use-spot-fleet]
+    usage: ecs-composex up [-h] -n NAME [--format {json,yaml,text}]
+                           [--region REGIONNAME] [--az ZONES] [-b BUCKETNAME]
+                           [--use-spot-fleet] -f DOCKERCOMPOSEXFILE
+                           [-d OUTPUTDIRECTORY]
+
+    Command 'render'
+    usage: ecs-composex render [-h] -n NAME [--format {json,yaml,text}]
+                               [--region REGIONNAME] [--az ZONES] [-b BUCKETNAME]
+                               [--use-spot-fleet] -f DOCKERCOMPOSEXFILE
+                               [-d OUTPUTDIRECTORY]
 
     Command 'config'
-    usage: ecs_composex config [-h] -n NAME -f DOCKERCOMPOSEXFILE
-                               [-d OUTPUTDIRECTORY] [--format {json,yaml,text}]
-                               [--region REGIONNAME] [--az ZONES] [-b BUCKETNAME]
-                               [--use-spot-fleet]
-
-    Command 'version'
-    usage: ecs_composex version [-h]
+    usage: ecs-composex config [-h] -f DOCKERCOMPOSEXFILE [-d OUTPUTDIRECTORY]
 
 
-CLI for `up` and `config`
+
+CLI for `up` and `render`
 
 .. code-block:: bash
 
@@ -87,6 +90,21 @@ CLI for `up` and `config`
                             Bucket name to upload the templates to
       --use-spot-fleet      Runs spotfleet for EC2. If used in combination of
                             --use-fargate, it will create an additional SpotFleet
+
+
+CLI for `config`
+
+.. code-block:: bash
+
+    usage: ecs-composex config [-h] -f DOCKERCOMPOSEXFILE [-d OUTPUTDIRECTORY]
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -f DOCKERCOMPOSEXFILE, --docker-compose-file DOCKERCOMPOSEXFILE
+                            Path to the Docker compose file
+      -d OUTPUTDIRECTORY, --output-dir OUTPUTDIRECTORY
+                            Output directory to write all the templates to.
+
 
 
 AWS Resources support

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -29,18 +29,18 @@ Usage
 =====
 
 .. code-block:: bash
-    :caption: Top level CLI
 
-    usage: ecs_composex [-h] {up,config,version,init} ...
+    usage: ecs-composex [-h] {up,render,config,init,version} ...
 
     positional arguments:
-      {up,config,version,init}
+      {up,render,config,init,version}
                             Command to execute.
         up                  Generates & Validates the CFN templates,
                             Creates/Updates stack in CFN
-        config              Generates & Validates the CFN templates locally. No
-                            upload to S3.
-        version             ECS ComposeX Version
+        render              Generates & Validates the CFN templates locally. No
+                            upload to S3
+        config              Merges docker-compose files to provide with the final
+                            compose content version
         init                Initializes your AWS Account with prerequisites
                             settings for ECS
         version             ECS ComposeX Version
@@ -49,23 +49,24 @@ Usage
       -h, --help            show this help message and exit
 
     Command 'up'
-    usage: ecs_composex up [-h] -n NAME -f DOCKERCOMPOSEXFILE [-d OUTPUTDIRECTORY]
-                           [--format {json,yaml,text}] [--region REGIONNAME]
-                           [--az ZONES] [-b BUCKETNAME] [--use-spot-fleet]
+    usage: ecs-composex up [-h] -n NAME [--format {json,yaml,text}]
+                           [--region REGIONNAME] [--az ZONES] [-b BUCKETNAME]
+                           [--use-spot-fleet] -f DOCKERCOMPOSEXFILE
+                           [-d OUTPUTDIRECTORY]
+
+    Command 'render'
+    usage: ecs-composex render [-h] -n NAME [--format {json,yaml,text}]
+                               [--region REGIONNAME] [--az ZONES] [-b BUCKETNAME]
+                               [--use-spot-fleet] -f DOCKERCOMPOSEXFILE
+                               [-d OUTPUTDIRECTORY]
 
     Command 'config'
-    usage: ecs_composex config [-h] -n NAME -f DOCKERCOMPOSEXFILE
-                               [-d OUTPUTDIRECTORY] [--format {json,yaml,text}]
-                               [--region REGIONNAME] [--az ZONES] [-b BUCKETNAME]
-                               [--use-spot-fleet]
-
-    Command 'version'
-    usage: ecs_composex version [-h]
+    usage: ecs-composex config [-h] -f DOCKERCOMPOSEXFILE [-d OUTPUTDIRECTORY]
 
 
 
 .. code-block:: bash
-    :caption: Up/Config CLI
+    :caption: CLI for up and render
 
     usage: ecs_composex up [-h] -n NAME -f DOCKERCOMPOSEXFILE [-d OUTPUTDIRECTORY]
                            [--format {json,yaml,text}] [--region REGIONNAME]
@@ -88,6 +89,20 @@ Usage
                             Bucket name to upload the templates to
       --use-spot-fleet      Runs spotfleet for EC2. If used in combination of
                             --use-fargate, it will create an additional SpotFleet
+
+
+.. code-block:: bash
+    :caption: CLI for config
+
+    usage: ecs-composex config [-h] -f DOCKERCOMPOSEXFILE [-d OUTPUTDIRECTORY]
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -f DOCKERCOMPOSEXFILE, --docker-compose-file DOCKERCOMPOSEXFILE
+                            Path to the Docker compose file
+      -d OUTPUTDIRECTORY, --output-dir OUTPUTDIRECTORY
+                            Output directory to write all the templates to.
+
 
 
 .. note::

--- a/ecs_composex/common/settings.py
+++ b/ecs_composex/common/settings.py
@@ -194,13 +194,13 @@ class ComposeXSettings(object):
         },
         {
             "name": no_upload_arg,
-            "help": "Merges docker-compose files to provide with the final compose content version",
+            "help": "Generates & Validates the CFN templates locally. No upload to S3",
         },
     ]
     validation_commands = [
         {
             "name": config_render_arg,
-            "help": "Generates & Validates the CFN templates locally. No upload to S3",
+            "help": "Merges docker-compose files to provide with the final compose content version",
         }
     ]
     neutral_commands = [

--- a/features/features/appmesh.feature
+++ b/features/features/appmesh.feature
@@ -1,15 +1,15 @@
 Feature: ecs_composex.appmesh
   @appmesh
   Scenario Outline: Mesh created with the services
-    Given I use <file_path> as my docker-compose file
+    Given I use <file_path> as my docker-compose file and <override_file> as override file
     And I want to create a VPC
     And I want to create a Cluster
     And I render the docker-compose to composex
     Then I should have a mesh created
 
     Examples:
-    |file_path|
-    |use-cases/blog.with_mesh.yml|
+    |file_path|override_file|
+    |use-cases/blog.yml|use-cases/blog.with_mesh.yml|
 
   @appmesh
   Scenario Outline: Shared or existing mesh

--- a/features/steps/common.py
+++ b/features/steps/common.py
@@ -47,9 +47,37 @@ def step_impl(context, file_path):
         else None,
         **{
             ComposeXSettings.name_arg: "test",
-            ComposeXSettings.command_arg: "config",
-            ComposeXSettings.input_file_arg: cases_path,
-            ComposeXSettings.no_upload_arg: True,
+            ComposeXSettings.command_arg: ComposeXSettings.no_upload_arg,
+            ComposeXSettings.input_file_arg: [cases_path],
+            ComposeXSettings.format_arg: "yaml",
+        },
+    )
+    context.settings.set_azs_from_api()
+    context.settings.set_bucket_name_from_account_id()
+
+
+@given(
+    "I use {file_path} as my docker-compose file and {override_file} as override file"
+)
+def step_impl(context, file_path, override_file):
+    """
+    Function to import the Docker file from use-cases.
+
+    :param context:
+    :param str file_path:
+    :param str override_file:
+    :return:
+    """
+    cases_path = path.abspath(f"{here()}/../{file_path}")
+    override_path = path.abspath(f"{here()}/../{override_file}")
+    context.settings = ComposeXSettings(
+        profile_name=getattr(context, "profile_name")
+        if hasattr(context, "profile_name")
+        else None,
+        **{
+            ComposeXSettings.name_arg: "test",
+            ComposeXSettings.command_arg: ComposeXSettings.no_upload_arg,
+            ComposeXSettings.input_file_arg: [cases_path, override_path],
             ComposeXSettings.format_arg: "yaml",
         },
     )

--- a/features/use-cases/blog.with_mesh.yml
+++ b/features/use-cases/blog.with_mesh.yml
@@ -5,61 +5,23 @@ version: '3.8'
 
 services:
   rproxy:
-    image: 373709687836.dkr.ecr.eu-west-1.amazonaws.com/blog-app-01-rproxy:latest
     ports:
       - 80:80
     deploy:
       replicas: 1
-      resources:
-        reservations:
-          cpus: "0.1"
-          memory: "32M"
-        limits:
-          cpus: "0.25"
-          memory: "64M"
       labels:
         ecs.task.family: app01
     x-configs:
-      network:
-        is_public: True
-        lb_type: application
-    depends_on:
-      - app01
+      use_xray: True
   app01:
-    image: 373709687836.dkr.ecr.eu-west-1.amazonaws.com/blog-app-01:appmesh
     ports:
       - 5000
+      - 5001:5000
     deploy:
-      resources:
-        reservations:
-          cpus: "0.25"
-          memory: "64M"
       labels:
         ecs.task.family: app01
-    environment:
-      LOGLEVEL: DEBUG
-    x-configs:
-      use_xray: True
-    links:
-      - app03:dateteller
-
-  app02:
-    image: 373709687836.dkr.ecr.eu-west-1.amazonaws.com/blog-app-02:appmesh
-    ports:
-      - 5000
-    deploy:
-      resources:
-        reservations:
-          cpus: "0.25"
-      labels:
-        ecs.task.family: app02
-    environment:
-      LOGLEVEL: DEBUG
-    x-configs:
-      use_xray: True
 
   app03:
-    image: 373709687836.dkr.ecr.eu-west-1.amazonaws.com/blog-app-02:appmesh
     ports:
       - 5000
     deploy:
@@ -68,15 +30,15 @@ services:
           cpus: "0.25"
       labels:
         ecs.task.family: app03
-    environment:
-      LOGLEVEL: DEBUG
-    x-configs:
-      use_xray: True
 
+  app04:
+    ports: []
+    image: nginx
 
 x-tags:
   owner: johnpreston
   contact: john@lambda-my-aws.io
+  another: one
 
 x-appmesh:
   Properties:

--- a/features/use-cases/blog.yml
+++ b/features/use-cases/blog.yml
@@ -13,6 +13,7 @@ services:
     image: 373709687836.dkr.ecr.eu-west-1.amazonaws.com/blog-app-01-rproxy:latest
     ports:
       - 80:80
+      - 443:443
     deploy:
       replicas: 2
       resources:
@@ -79,7 +80,3 @@ services:
       LOGLEVEL: DEBUG
     x-configs:
       use_xray: True
-
-x-tags:
-  owner: johnpreston
-  contact: john@lambda-my-aws.io

--- a/pytests/test_aws.py
+++ b/pytests/test_aws.py
@@ -150,11 +150,10 @@ def create_settings(updated_content, case_path):
         session=session,
         **{
             ComposeXSettings.name_arg: "test",
-            ComposeXSettings.command_arg: "config",
+            ComposeXSettings.command_arg: ComposeXSettings.no_upload_arg,
             ComposeXSettings.input_file_arg: path.abspath(
                 f"{here}/../features/use-cases/vpc/vpc_from_tags.yml"
             ),
-            ComposeXSettings.no_upload_arg: True,
             ComposeXSettings.format_arg: "yaml",
         },
     )

--- a/pytests/test_cluster.py
+++ b/pytests/test_cluster.py
@@ -50,8 +50,7 @@ def test_lookup(existing_cluster, nonexisting_cluster):
         session=session,
         **{
             ComposeXSettings.name_arg: "test",
-            ComposeXSettings.command_arg: "config",
-            ComposeXSettings.no_upload_arg: True,
+            ComposeXSettings.command_arg: ComposeXSettings.no_upload_arg,
             ComposeXSettings.format_arg: "yaml",
         },
     )
@@ -65,8 +64,7 @@ def test_lookup(existing_cluster, nonexisting_cluster):
         session=session,
         **{
             ComposeXSettings.name_arg: "test",
-            ComposeXSettings.command_arg: "config",
-            ComposeXSettings.no_upload_arg: True,
+            ComposeXSettings.command_arg: ComposeXSettings.no_upload_arg,
             ComposeXSettings.format_arg: "yaml",
         },
     )

--- a/pytests/test_dns.py
+++ b/pytests/test_dns.py
@@ -70,11 +70,10 @@ def create_settings(updated_content, case_path):
         session=session,
         **{
             ComposeXSettings.name_arg: "test",
-            ComposeXSettings.command_arg: "config",
+            ComposeXSettings.command_arg: ComposeXSettings.no_upload_arg,
             ComposeXSettings.input_file_arg: path.abspath(
                 f"{here}/../use-cases/blog.yml"
             ),
-            ComposeXSettings.no_upload_arg: True,
             ComposeXSettings.format_arg: "yaml",
         },
     )

--- a/use-cases/blog-all-features.yml
+++ b/use-cases/blog-all-features.yml
@@ -3,76 +3,21 @@
 
 version: '3.8'
 
-x-configs:
-  app:
-    network:
-      use_cloudmap: True
-
 services:
-  rproxy:
-    image: 373709687836.dkr.ecr.eu-west-1.amazonaws.com/blog-app-01-rproxy:latest
-    ports:
-      - 80:80
-    deploy:
-      replicas: 2
-      resources:
-        reservations:
-          cpus: "0.1"
-          memory: "32M"
-        limits:
-          cpus: "0.25"
-          memory: "64M"
-      labels:
-        ecs.task.family: bignicefamily
-    x-configs:
-      network:
-        is_public: True
-        lb_type: application
-    depends_on:
-      - app01
-  app01:
-    image: 373709687836.dkr.ecr.eu-west-1.amazonaws.com/blog-app-01:appmesh
-    ports:
-      - 5000
-    deploy:
-      resources:
-        reservations:
-          cpus: "0.25"
-          memory: "64M"
-      labels:
-        ecs.task.family: bignicefamily
-    environment:
-      LOGLEVEL: DEBUG
-    x-configs:
-      use_xray: True
-    links:
-      - app03:dateteller
 
-  app02:
-    image: 373709687836.dkr.ecr.eu-west-1.amazonaws.com/blog-app-02:latest
-    ports:
-      - 5000
+  rproxy:
     deploy:
-      resources:
-        reservations:
-          cpus: "0.25"
-          memory: "64M"
+      labels:
+        ecs.task.family: bignicefamily
+  app01:
+    deploy:
+      labels:
+        ecs.task.family: bignicefamily
     environment:
-      LOGLEVEL: DEBUG
-    x-configs:
-      use_xray: True
+      name: toto
+      LOGLEVEL: INFO
 
   app03:
-    image: 373709687836.dkr.ecr.eu-west-1.amazonaws.com/blog-app-02:latest
-    ports:
-      - 5000
-    deploy:
-      resources:
-        reservations:
-          cpus: "0.25"
-          memory: "64M"
-    environment:
-      LOGLEVEL: DEBUG
     x-configs:
       use_xray: True
       iam:

--- a/use-cases/blog-with-mesh.yml
+++ b/use-cases/blog-with-mesh.yml
@@ -5,74 +5,21 @@ version: '3.8'
 
 services:
   rproxy:
-    image: 373709687836.dkr.ecr.eu-west-1.amazonaws.com/blog-app-01-rproxy:latest
-    ports:
-      - 80:80
     deploy:
-      replicas: 1
-      resources:
-        reservations:
-          cpus: "0.1"
-          memory: "32M"
-        limits:
-          cpus: "0.25"
-          memory: "64M"
       labels:
-        ecs.task.family: app01
-    x-configs:
-      network:
-        is_public: True
-        lb_type: application
-    depends_on:
-      - app01
+        ecs.task.family: bignicefamily
   app01:
-    image: 373709687836.dkr.ecr.eu-west-1.amazonaws.com/blog-app-01:appmesh
-    ports:
-      - 5000
     deploy:
-      resources:
-        reservations:
-          cpus: "0.25"
-          memory: "64M"
       labels:
-        ecs.task.family: app01
+        ecs.task.family: bignicefamily
     environment:
-      LOGLEVEL: DEBUG
-    x-configs:
-      use_xray: True
-    links:
-      - app03:dateteller
-
-  app02:
-    image: 373709687836.dkr.ecr.eu-west-1.amazonaws.com/blog-app-02:appmesh
-    ports:
-      - 5000
-    deploy:
-      resources:
-        reservations:
-          cpus: "0.25"
-      labels:
-        ecs.task.family: app02
-    environment:
-      LOGLEVEL: DEBUG
-    x-configs:
-      use_xray: True
+      name: toto
 
   app03:
-    image: 373709687836.dkr.ecr.eu-west-1.amazonaws.com/blog-app-02:appmesh
-    ports:
-      - 5000
-    deploy:
-      resources:
-        reservations:
-          cpus: "0.25"
-      labels:
-        ecs.task.family: app03
-    environment:
-      LOGLEVEL: DEBUG
     x-configs:
       use_xray: True
-
+      iam:
+        boundary: arn:aws:iam::aws:policy/PowerUserAccess
 
 x-tags:
   owner: johnpreston
@@ -87,7 +34,7 @@ x-appmesh:
         protocol: http
       - name: app02
         protocol: http
-      - name: app01
+      - name: bignicefamily
         protocol: http
         backends:
           - dateteller # Points to the dateteller service, not router!
@@ -112,7 +59,7 @@ x-appmesh:
                   weight: 1
     services:
       - name: api
-        node: app01
+        node: bignicefamily
       - name: dateteller
         router: dateteller
 
@@ -123,16 +70,36 @@ x-dns:
     Name: lambda-my-aws.io
 
 x-vpc:
-  Lookup:
-    VpcId:
-      tags:
-        - Name: vpcwork
-    AppSubnets:
-      tags:
-        - vpc::usage: application
-    StorageSubnets:
-      tags:
-        - vpc::usage: storage
-    PublicSubnets:
-      tags:
-        - vpc::usage: public
+  Create:
+    VpcCidr: 10.21.42.0/24
+    SingleNat: True
+
+#  Lookup:
+#    VpcId:
+#      tags:
+#        - Name: vpcwork
+#    AppSubnets:
+#      tags:
+#        - vpc::usage: application
+#    StorageSubnets:
+#      tags:
+#        - vpc::usage: storage
+#    PublicSubnets:
+#      tags:
+#        - vpc::usage: public
+
+
+x-cluster:
+#  Properties:
+#    CapacityProviders:
+#      - FARGATE
+#      - FARGATE_SPOT
+#    ClusterName: testabcd
+#    DefaultCapacityProviderStrategy:
+#      - CapacityProvider: FARGATE_SPOT
+#        Weight: 4
+#        Base: 2
+#      - CapacityProvider: FARGATE
+#        Weight: 1
+
+  Lookup: test2

--- a/use-cases/blog.yml
+++ b/use-cases/blog.yml
@@ -16,8 +16,6 @@ services:
         limits:
           cpus: "0.25"
           memory: "64M"
-      labels:
-        ecs.task.family: app01
     x-configs:
       network:
         is_public: True
@@ -33,8 +31,6 @@ services:
         reservations:
           cpus: "0.25"
           memory: "64M"
-      labels:
-        ecs.task.family: app01
     environment:
       LOGLEVEL: DEBUG
     x-configs:
@@ -51,8 +47,6 @@ services:
         reservations:
           cpus: "0.25"
           memory: "64M"
-      labels:
-        ecs.task.family: app02
     environment:
       LOGLEVEL: DEBUG
     x-configs:
@@ -67,8 +61,6 @@ services:
         reservations:
           cpus: "0.25"
           memory: "64M"
-      labels:
-        ecs.task.family: app03
     environment:
       LOGLEVEL: DEBUG
     x-configs:


### PR DESCRIPTION
Allows to mimic the docker-compose override behaviour.
No default file search, files have to be explicitly specified, in order of importance (source first, expansion/override next).
For now, the x-sections are not merged, so two files with conflicting x-settings will override each other if the same resources are defined.