### PR TITLE
Release 0.6.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,20 @@
 History
 =======
 
+0.6.0 (2020-08-03)
+===================
+
+New features:
+* `Docker-compose multi-files (override support) <https://github.com/lambda-my-aws/ecs_composex/issues/121>`_
+
+The new CLI uses positional arguments matching a specific command which drives what's executed onwards.
+Trying to re-implement features as close to the docker-compose CLI as possible.
+
+* **config** allows to get the YAML file render of the docker-compose files put together.
+* **render** will put all input files together and generate the CFN templates accordingly.
+* **up** will deploy do the same as render, and deploy to AWS CFN.
+
+
 0.5.3 (2020-07-30)
 ==================
 

--- a/ecs_composex/__init__.py
+++ b/ecs_composex/__init__.py
@@ -20,4 +20,4 @@
 
 __author__ = """John Preston"""
 __email__ = "john@lambda-my-aws.io"
-__version__ = "0.5.3"
+__version__ = "0.6.0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.3
+current_version = 0.6.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/lambda-my-aws/ecs_composex",
-    version="0.5.3",
+    version="0.6.0",
     zip_safe=False,
 )


### PR DESCRIPTION
New features:
* `Docker-compose multi-files (override support) <https://github.com/lambda-my-aws/ecs_composex/issues/121>`_

The new CLI uses positional arguments matching a specific command which drives what's executed onwards.
Trying to re-implement features as close to the docker-compose CLI as possible.

* **config** allows to get the YAML file render of the docker-compose files put together.
* **render** will put all input files together and generate the CFN templates accordingly.
* **up** will deploy do the same as render, and deploy to AWS CFN.