### PR TITLE
Patched version of 0.8.9 with previews for 0.9.0

### DIFF
--- a/ecs_composex/__init__.py
+++ b/ecs_composex/__init__.py
@@ -20,4 +20,4 @@
 
 __author__ = """John Preston"""
 __email__ = "john@lambda-my-aws.io"
-__version__ = "0.8.8"
+__version__ = "0.8.9"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.8
+current_version = 0.8.9
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/lambda-my-aws/ecs_composex",
-    version="0.8.8",
+    version="0.8.9",
     zip_safe=False,
 )


### PR DESCRIPTION
Docs updated to align with the upcoming 0.9.0 release

Bump version: 0.8.8 → 0.8.9