### PR TITLE
pre-0.9 resources migration path

### DIFF
--- a/ecs_composex/common/compose_resources.py
+++ b/ecs_composex/common/compose_resources.py
@@ -1,4 +1,4 @@
-﻿#  -*- coding: utf-8 -*-
+#  -*- coding: utf-8 -*-
 #   ECS ComposeX <https://github.com/lambda-my-aws/ecs_composex>
 #   Copyright (C) 2020  John Mille <john@lambda-my-aws.io>
 #  #
@@ -296,20 +296,28 @@ class XResource(object):
                     definition[2],
                 )
             name = NONALPHANUM.sub("", definition[0])
+            if len(definition) == 5 and definition[4]:
+                LOG.debug(f"Adding portback output for {self.name}")
+                export = Export(If(
+                        USE_STACK_NAME_CON_T,
+                        Sub(f"${{{AWS_STACK_NAME}}}{DELIM}{self.name}{DELIM}{definition[4]}"),
+                        Sub(f"${{{ROOT_STACK_NAME.title}}}{DELIM}{self.name}{DELIM}{definition[4]}"),
+                    ))
+            else:
+                export = Export(If(
+                        USE_STACK_NAME_CON_T,
+                        Sub(f"${{{AWS_STACK_NAME}}}{DELIM}{name}"),
+                        Sub(f"${{{ROOT_STACK_NAME.title}}}{DELIM}{name}"),
+                    ))
             self.attributes_outputs[output_prop_name] = {
                 "Name": name,
                 "Output": Output(
                     name,
                     Value=value,
-                    Export=Export(
-                        If(
-                            USE_STACK_NAME_CON_T,
-                            Sub(f"${{{AWS_STACK_NAME}}}{DELIM}{name}"),
-                            Sub(f"${{{ROOT_STACK_NAME.title}}}{DELIM}{name}"),
-                        )
-                    ),
+                    Export=export
                 ),
             }
+
         for attr in self.attributes_outputs.values():
             self.outputs.append(attr["Output"])
 

--- a/ecs_composex/rds/rds_stack.py
+++ b/ecs_composex/rds/rds_stack.py
@@ -69,24 +69,27 @@ class Rds(XResource):
         Method to init the RDS Output attributes
         """
         self.output_properties = {
-            DB_NAME.title: (self.logical_name, self.cfn_resource, Ref, None),
+            DB_NAME.title: (self.logical_name, self.cfn_resource, Ref, None, "DbName"),
             DB_ENDPOINT_PORT: (
                 f"{self.logical_name}{DB_ENDPOINT_PORT}",
                 self.cfn_resource,
                 GetAtt,
                 DB_ENDPOINT_PORT,
+                "Port"
             ),
             self.db_secret.title: (
                 self.db_secret.title,
                 self.db_secret,
                 Ref,
                 None,
+                "SecretArn"
             ),
             self.db_sg.title: (
                 self.db_sg.title,
                 self.db_sg,
                 GetAtt,
                 "GroupId",
+                "GroupId"
             ),
         }
 

--- a/ecs_composex/rds/rds_stack.py
+++ b/ecs_composex/rds/rds_stack.py
@@ -89,7 +89,7 @@ class Rds(XResource):
                 self.db_sg,
                 GetAtt,
                 "GroupId",
-                "GroupId"
+                "RdsDbSecurityGroup"
             ),
         }
 

--- a/ecs_composex/sqs/sqs_stack.py
+++ b/ecs_composex/sqs/sqs_stack.py
@@ -71,18 +71,20 @@ class Queue(XResource):
 
     def init_outputs(self):
         self.output_properties = {
-            SQS_URL.title: (self.logical_name, self.cfn_resource, Ref, None),
+            SQS_URL.title: (self.logical_name, self.cfn_resource, Ref, None, "Url"),
             SQS_ARN.title: (
                 f"{self.logical_name}{SQS_ARN.title}",
                 self.cfn_resource,
                 GetAtt,
                 SQS_ARN.title,
+                "Arn"
             ),
             SQS_NAME.title: (
                 f"{self.logical_name}{SQS_NAME.title}",
                 self.cfn_resource,
                 GetAtt,
                 SQS_NAME.title,
+                "QueueName"
             ),
         }
 


### PR DESCRIPTION
For stacks pre-dating the GetAtt from stacks to stacks and using Import, for the following resources, exports are created using the previous naming convention

* RDS
* SQS
