### PR TITLE
Support for env_file

### DIFF
--- a/ecs_composex/ecs/ecs_iam.py
+++ b/ecs_composex/ecs/ecs_iam.py
@@ -30,16 +30,16 @@ from ecs_composex.ecs.ecs_params import (
 from ecs_composex.iam import service_role_trust_policy
 
 
-def add_service_roles(template):
+def add_service_roles(task_family):
     """
     Function to create the IAM roles for the ECS task
 
-    :param template: ecs_service template to add the resources to
-    :type template: troposphere.Template
+    :param task_family: The task family to add the roles to
+    :type task_family: ecs_composex.common.compose_services.ComposeFamily
     """
-    Role(
+    task_family.exec_role = Role(
         EXEC_ROLE_T,
-        template=template,
+        template=task_family.template,
         AssumeRolePolicyDocument=service_role_trust_policy("ecs-tasks"),
         Description=Sub(
             f"Execution role for ${{{SERVICE_NAME_T}}} in ${{{CLUSTER_NAME_T}}}"
@@ -100,9 +100,9 @@ def add_service_roles(template):
             )
         ],
     )
-    Role(
+    task_family.task_role = Role(
         TASK_ROLE_T,
-        template=template,
+        template=task_family.template,
         AssumeRolePolicyDocument=service_role_trust_policy("ecs-tasks"),
         Description=Sub(f"TaskRole - ${{{SERVICE_NAME_T}}} in ${{{CLUSTER_NAME_T}}}"),
         ManagedPolicyArns=[],

--- a/ecs_composex/ecs/ecs_template.py
+++ b/ecs_composex/ecs/ecs_template.py
@@ -296,3 +296,4 @@ def generate_services(settings):
                 ),
             }
         )
+        family.upload_services_env_files(settings)

--- a/use-cases/blog.features.yml
+++ b/use-cases/blog.features.yml
@@ -20,6 +20,7 @@ secrets:
           Key: test
 services:
   app01:
+    env_file: ./use-cases/env-files/dummy.env
     deploy:
       labels:
         ecs.task.family: bignicefamily
@@ -67,6 +68,8 @@ services:
     x-scaling:
       range: "1-4"
   app02:
+    env_file:
+      - ./use-cases/env-files/dummy.env
     deploy:
       labels:
         ecs.task.family: youtoo


### PR DESCRIPTION
When defining env_file in docker-compose, files now are uploaded to S3 and the [EnvironmentFiles](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-environmentfiles) attribute of container definition is automatically added
