### PR TITLE
Not try to interpolate ${AWS::PseudoParamerters} with env vars

### DIFF
--- a/ecs_composex/common/envsubst.py
+++ b/ecs_composex/common/envsubst.py
@@ -22,8 +22,8 @@ Module to do a better env variables handling.
 import os
 import re
 
-ENV_VAR_REGEXP = r"(?<!\\)\$(\w+|\{([^}]*)\})"
-SPECIAL_INTERPOLATION = r"(?<!\\)(\$(\{(([^}]+)(\:[+-=]{1}))([^}]+)\}))"
+ENV_VAR_REGEXP = r"(?<!\\)\$(\w+|\{(?!AWS::)([^}]*)\})"
+SPECIAL_INTERPOLATION = r"(?<!\\)(\$(\{(((?!AWS::)[^}]+)(\:[+-=]{1}))([^}]+)\}))"
 IF_UNDEFINED = r":-"
 IF_DEFINED = r":+"
 
@@ -51,5 +51,5 @@ def expandvars(path, default=None, skip_escaped=True):
             match.group(0) if default is None else default,
         )
 
-    re_string = (r"(?<!\\)" if skip_escaped else "") + r"\$(\w+|\{([^}]*)\})"
+    re_string = (r"(?<!\\)" if skip_escaped else "") + r"\$(\w+|\{(?!AWS::)([^}]*)\})"
     return re.sub(re_string, replace_var, path)

--- a/pytests/test_envsubst.py
+++ b/pytests/test_envsubst.py
@@ -18,6 +18,7 @@
 from pytest import fixture
 from ecs_composex.common.envsubst import expandvars
 
+
 @fixture
 def mock_env_vars(monkeypatch):
     monkeypatch.setenv("TOTO", "toto")
@@ -37,7 +38,14 @@ def test_envsubst(mock_env_vars):
         ("$TOTO -- $TATA", "toto -- tata"),
         ("${ABCD:-Cake}", "Cake"),
         ("${TOTO:-Cake}", "toto"),
-        ("$TOTO -- ${TATA:+SUCCESS} -- ${AWS::AccountId}", "toto -- SUCCESS -- ${AWS::AccountId}")
+        (
+            "$TOTO -- ${TATA:+SUCCESS} -- ${AWS::AccountId}",
+            "toto -- SUCCESS -- ${AWS::AccountId}",
+        ),
+        (
+            "https://s3.${AWS::Region}.${AWS::URLSuffix}",
+            "https://s3.${AWS::Region}.${AWS::URLSuffix}",
+        ),
     ]
     for test in tests:
         assert expandvars(test[0]) == test[1]


### PR DESCRIPTION
`https://s3.${AWS::Region}` is no longer interpolated to `https://s3..` 
