### PR TITLE
Fix S3 name generation, events subnet param

### DIFF
--- a/ecs_composex/events/events_ecs.py
+++ b/ecs_composex/events/events_ecs.py
@@ -173,7 +173,7 @@ def define_service_targets(stack, rule, cluster_arn):
             EcsParameters=EcsParameters(
                 NetworkConfiguration=NetworkConfiguration(
                     AwsVpcConfiguration=AwsVpcConfiguration(
-                        Subnets=Ref(service_sg_param),
+                        Subnets=Ref(service_subnets_param),
                         SecurityGroups=[Ref(service_sg_param)],
                     )
                 ),

--- a/ecs_composex/s3/s3_template.py
+++ b/ecs_composex/s3/s3_template.py
@@ -259,5 +259,6 @@ def generate_bucket(bucket):
     LOG.debug(bucket_name)
     LOG.debug(final_bucket_name)
     props = import_record_properties(bucket.properties, s3.Bucket)
+    props['BucketName'] = final_bucket_name
     bucket.cfn_resource = s3.Bucket(bucket.logical_name, **props)
     return bucket


### PR DESCRIPTION
Fix bug in S3 name generation when using ExpandRegionToBucket/ExpandAccountIdToBucket

Fix incorrect subnets param in events