### PR TITLE
Working templates generate for RDS <> S3

### DIFF
--- a/ecs_composex/common/settings.py
+++ b/ecs_composex/common/settings.py
@@ -408,6 +408,7 @@ class ComposeXSettings(object):
         self.subnets_parameters = []
         self.subnets_mappings = {}
         self.secrets_mappings = {}
+        self.mappings = {}
         self.families = {}
         self.account_id = None
         self.output_dir = self.default_output_dir

--- a/ecs_composex/ecs_composex.py
+++ b/ecs_composex/ecs_composex.py
@@ -188,23 +188,22 @@ def apply_x_configs_to_ecs(settings, root_stack):
             invoke_x_to_ecs(None, settings, root_stack, resource)
 
 
-def apply_x_to_x_configs(root_template, settings):
+def apply_x_to_x_configs(root_stack, settings):
     """
     Function to iterate over each XStack and trigger cross-x resources configurations functions
 
-    :param troposphere.Template root_template: the ECS ComposeX root template
+    :param ComposeXStack root_stack: the ECS ComposeX root template
     :param ComposeXSettings settings: The execution settings
     :return:
     """
-    for resource_name in root_template.resources:
-        resource = root_template.resources[resource_name]
+    for resource_name, resource in root_stack.stack_template.resources.items():
         if (
             issubclass(type(resource), ComposeXStack)
-            and resource.name in SUPPORTED_X_MODULES
+            and resource.name in SUPPORTED_X_MODULE_NAMES
             and hasattr(resource, "add_xdependencies")
             and not resource.is_void
         ):
-            resource.add_xdependencies(root_template, settings.compose_content)
+            resource.add_xdependencies(root_stack, settings)
 
 
 def add_compute(root_template, settings, vpc_stack):
@@ -359,7 +358,7 @@ def generate_full_template(settings):
         settings,
         root_stack,
     )
-    apply_x_to_x_configs(root_stack.stack_template, settings)
+    apply_x_to_x_configs(root_stack, settings)
     if settings.use_appmesh:
         mesh = Mesh(
             settings.compose_content["x-appmesh"], root_stack, settings, dns_settings

--- a/ecs_composex/rds/rds_db_template.py
+++ b/ecs_composex/rds/rds_db_template.py
@@ -567,7 +567,6 @@ def apply_extra_parameters(settings, stack, db, db_template):
             LOG.error(
                 f"The property {name} is of type {type(db.parameters[name])}. Expected {config[0]}. Skipping"
             )
-            continue
 
 
 def generate_database_template(db, settings):

--- a/ecs_composex/rds/rds_iam_access.py
+++ b/ecs_composex/rds/rds_iam_access.py
@@ -1,0 +1,223 @@
+﻿#  -*- coding: utf-8 -*-
+#   ECS ComposeX <https://github.com/lambda-my-aws/ecs_composex>
+#   Copyright (C) 2020  John Mille <john@lambda-my-aws.io>
+#  #
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#  #
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#  #
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+
+from troposphere import (
+    AWS_PARTITION,
+    AWS_STACK_NAME,
+)
+from troposphere import Parameter
+from troposphere import Ref, Sub, GetAtt
+from troposphere.iam import Role as IamRole, Policy as IamPolicy
+from troposphere.rds import DBClusterRole
+
+from ecs_composex.common import LOG, keyisset
+from ecs_composex.iam import service_role_trust_policy
+
+S3_KEY = "x-s3"
+
+
+def set_from_x_s3(settings, stack, db, db_template, bucket_name):
+    """
+    Function to link the RDS DB to a Bucket defined in x-s3
+
+    :param settings:
+    :param db:
+    :param db_template:
+    :param str bucket_name:
+    :return:
+    """
+    resource = None
+    if not keyisset(S3_KEY, settings.compose_content):
+        raise KeyError(
+            f"No Buckets defined in the Compose file under {S3_KEY}.",
+            settings.compose_content.keys(),
+        )
+    bucket_name = bucket_name.strip("x-s3::")
+    buckets = settings.compose_content[S3_KEY]
+    if bucket_name not in [res.name for res in buckets.values()]:
+        LOG.error(
+            f"No bucket {bucket_name} in x-s3. Buckets defined: {[res.name for res in buckets.values()]}"
+        )
+        return
+    for resource in buckets.values():
+        if bucket_name == resource.name:
+            break
+    if not resource:
+        return
+    if resource.cfn_resource:
+        param = Parameter(f"{resource.logical_name}Arn", Type="String")
+        db_template.add_parameter(param)
+        if stack.parent_stack:
+            stack.parent_stack.stack_template.add_parameter(param)
+            stack.parent_stack.Parameters.update(
+                {param.title: GetAtt("s3", f"Outputs.{resource.logical_name}Arn")}
+            )
+        stack.Parameters.update({param.title: Ref(param.title)})
+        return Sub(f"${{{param.title}}}/*")
+
+
+def add_s3_access(settings, stack, db, config, db_template, subconfig):
+    """
+    Function to define the IAM Policy for S3Import access
+
+    :param settings:
+    :param db:
+    :param config:
+    :param db_template:
+    :param subconfig:
+    :return:
+    """
+    bucket_arn_path_re = re.compile(
+        r"(arn:aws:s3:::(?:[a-zA-Z0-9-.]+))(/path/to/files)?"
+    )
+    bucket_name_path_re = re.compile(r"(?:[a-zA-Z0-9-.]+)(/path/to/files)?")
+    bucket_arns = []
+    for bucket in config:
+        bucket_arn = None
+        if not isinstance(bucket, str):
+            raise TypeError(
+                "All buckets defined in IamAccess/Buckets must be of type",
+                str,
+                "Got",
+                type(bucket),
+            )
+        if bucket.startswith("x-s3"):
+            bucket_arn = set_from_x_s3(settings, stack, db, db_template, bucket)
+        elif bucket.startswith("arn:aws"):
+            if not bucket_arn_path_re.match(bucket):
+                raise ValueError(
+                    "The Bucket ARN provided is not valid. Expecting format",
+                    bucket_arn_path_re.pattern,
+                )
+            elif bucket_arn_path_re.match(bucket):
+                bucket_arn = bucket
+            else:
+                bucket_arn = f"{bucket}/*"
+
+        elif not bucket.startswith("arn:aws"):
+            if not bucket_name_path_re.match(bucket):
+                raise ValueError(
+                    "Bucket name and path are not valid. Expecting format",
+                    bucket_name_path_re.pattern,
+                )
+            elif (
+                bucket_name_path_re.match(bucket)
+                and len(bucket_name_path_re.match(bucket).groups()) == 1
+            ):
+                bucket_arn = Sub(f"arn:${{{AWS_PARTITION}}}:s3:::{bucket}/*")
+            elif (
+                bucket_name_path_re.match(bucket)
+                and len(bucket_name_path_re.match(bucket).groups()) == 2
+            ):
+                bucket_arn = Sub(f"arn:${{{AWS_PARTITION}}}:s3:::{bucket}")
+
+        if bucket_arn:
+            bucket_arns.append(bucket_arn)
+
+    policy = IamPolicy(
+        PolicyName=f"S3AccessFor{db.logical_name}",
+        PolicyDocument={
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "S3ObjectsAccess",
+                    "Effect": "Allow",
+                    "Action": ["s3:GetObject*", "s3:PutObject*"],
+                    "Resource": bucket_arns,
+                }
+            ],
+        },
+    )
+    return policy
+
+
+def add_iam_access(settings, stack, db, data, db_template, boundary):
+    """
+    Function to add IAM role and permissions to the DB to get access to external resources
+
+    :param ecs_composex.common.settings.ComposeXSettings settings:
+    :param ecs_composex.common.stacks.ComposeXStack stack:
+    :param dict data: The configuration for IamAccess
+    :param ecs_composex.rds.rds_stack.Rds db db:
+    :param troposphere.Template db_template:
+    :param boundary:
+    :return:
+    """
+    print("CONFIG", data)
+    if db.cfn_resource and hasattr(db.cfn_resource, "AssociatedRoles"):
+        LOG.warning(
+            "The db properties already had AssociatedRoles defined."
+            " Only will add ones without the feature already defined"
+        )
+        roles = getattr(db.cfn_resource, "AssociatedRoles")
+    else:
+        roles = []
+    allowed_keys = {
+        "Buckets": (list, add_s3_access, "s3Import"),
+        "CloudWatch": (bool, None, None),
+    }
+    if not all(key in allowed_keys.keys() for key in data.keys()):
+        raise KeyError(
+            "The only valid parameters for IamAccess are",
+            allowed_keys.keys(),
+            "Got",
+            data.keys(),
+        )
+    for name, subconfig in allowed_keys.items():
+        print("ITEM", name, subconfig)
+        if keyisset(name, data) and not isinstance(data[name], subconfig[0]):
+            LOG.error(
+                f"{name} is of type {type(data[name])}. Expected {subconfig[0]}. Skipping"
+            )
+            continue
+
+        elif (
+            keyisset(name, data)
+            and isinstance(data[name], subconfig[0])
+            and subconfig[1]
+        ):
+            if (
+                roles
+                and subconfig[2]
+                and subconfig[2] in [role["FeatureName"] for role in roles]
+            ):
+                LOG.warning(
+                    f"Feature {data[2]} is already defined in from the properties. Skipping"
+                )
+                continue
+            else:
+                policy = subconfig[1](
+                    settings, stack, db, data[name], db_template, subconfig
+                )
+                print("POLICY", policy)
+                role = IamRole(
+                    f"{db.logical_name}{subconfig[2]}IamRole",
+                    AssumeRolePolicyDocument=service_role_trust_policy("rds"),
+                    Description=Sub(
+                        f"{db.logical_name}{subconfig[2]}IamRole in ${{{AWS_STACK_NAME}}}"
+                    ),
+                    Policies=[policy],
+                    PermissionsBoundary=boundary,
+                    MaxSessionDuration=900,
+                )
+                db_template.add_resource(role)
+                roles.append(
+                    DBClusterRole(FeatureName=subconfig[2], RoleArn=GetAtt(role, "Arn"))
+                )
+        setattr(db.cfn_resource, "AssociatedRoles", roles)

--- a/ecs_composex/rds/rds_iam_access.py
+++ b/ecs_composex/rds/rds_iam_access.py
@@ -19,7 +19,7 @@ import re
 
 from troposphere import AWS_PARTITION, AWS_STACK_NAME, AWS_NO_VALUE
 from troposphere import Parameter
-from troposphere import Ref, Sub, GetAtt
+from troposphere import Ref, Sub, GetAtt, FindInMap
 from troposphere.iam import Role as IamRole, Policy as IamPolicy
 from troposphere.rds import DBClusterRole
 
@@ -71,6 +71,10 @@ def set_from_x_s3(settings, stack, db, db_template, bucket_name):
         return
     if resource.cfn_resource:
         return get_s3_bucket_arn_from_resource(db_template, stack, resource)
+    elif resource.lookup and keyisset("s3", settings.mappings):
+        if "s3" not in db_template.mappings:
+            db_template.add_mapping("s3", settings.mappings["s3"])
+            return FindInMap("s3", resource.logical_name, "Arn")
 
 
 def import_bucket_from_arn(bucket):

--- a/ecs_composex/rds/rds_iam_access.py
+++ b/ecs_composex/rds/rds_iam_access.py
@@ -72,9 +72,9 @@ def set_from_x_s3(settings, stack, db, db_template, bucket_name):
     if resource.cfn_resource:
         return get_s3_bucket_arn_from_resource(db_template, stack, resource)
     elif resource.lookup and keyisset("s3", settings.mappings):
-        if "s3" not in db_template.mappings:
+        if not db_template.mappings or "s3" not in db_template.mappings:
             db_template.add_mapping("s3", settings.mappings["s3"])
-            return FindInMap("s3", resource.logical_name, "Arn")
+        return FindInMap("s3", resource.logical_name, "Arn")
 
 
 def import_bucket_from_arn(bucket):

--- a/ecs_composex/rds/rds_iam_access.py
+++ b/ecs_composex/rds/rds_iam_access.py
@@ -246,7 +246,6 @@ def add_iam_access(settings, stack, db, data, db_template, boundary):
                 LOG.warning(
                     f"Feature {data[2]} is already defined in from the properties. Skipping"
                 )
-                continue
             else:
                 policy = subconfig[1](
                     settings, stack, db, data[name], db_template, subconfig

--- a/ecs_composex/s3/s3_ecs.py
+++ b/ecs_composex/s3/s3_ecs.py
@@ -31,6 +31,7 @@ from ecs_composex.resource_settings import (
     generate_resource_permissions,
     get_selected_services,
 )
+from ecs_composex.s3.s3_params import MOD_KEY
 from ecs_composex.s3.s3_aws import lookup_bucket_config
 from ecs_composex.s3.s3_perms import ACCESS_TYPES
 
@@ -283,6 +284,11 @@ def s3_to_ecs(xresources, services_stack, res_root_stack, settings):
     :return:
     """
     buckets_mappings = {}
+    if res_root_stack.is_void:
+        key = MOD_KEY
+    else:
+        key = res_root_stack.title
+    settings.mappings[key] = buckets_mappings
     new_resources = [
         xresources[name] for name in xresources if not xresources[name].lookup
     ]

--- a/ecs_composex/s3/s3_params.py
+++ b/ecs_composex/s3/s3_params.py
@@ -19,7 +19,8 @@ from os import path
 from ecs_composex.common.ecs_composex import X_KEY
 from troposphere import Parameter
 
-RES_KEY = f"{X_KEY}{path.basename(path.dirname(path.abspath(__file__)))}"
+MOD_KEY = path.basename(path.dirname(path.abspath(__file__)))
+RES_KEY = f"{X_KEY}{MOD_KEY}"
 
 S3_ARN_REGEX = r"arn:(aws|aws-gov|aws-cn):s3:::([a-zA-Z0-9-.]+$)"
 

--- a/ecs_composex/sns/sns_stack.py
+++ b/ecs_composex/sns/sns_stack.py
@@ -114,14 +114,14 @@ class XStack(ComposeXStack):
         Function to handle the SQS configuration to allow SNS to send messages to queues.
         """
 
-    def add_xdependencies(self, root_template, content):
+    def add_xdependencies(self, root_stack, settings):
         """
         Method to add a dependencies from other X-Resources
-        :param troposphere.Template root_template: The ComposeX Root template
-        :param dict content: the compose file content
+        :param ComposeXStack root_stack: The ComposeX Root template
+        :param ecs_composex.common.ComposeXSettings settings:
         """
-        resources = root_template.resources
+        resources = root_stack.stack_template.resources
         sqs_res = SQS_KEY.strip("x-") if SQS_KEY.startswith("x-") else SQS_KEY
-        if SQS_KEY in content and sqs_res in resources:
+        if SQS_KEY in settings.compose_content and sqs_res in resources:
             self.DependsOn.append(sqs_res)
-            self.handle_sqs(root_template, resources[sqs_res])
+            self.handle_sqs(root_stack.stack_template, resources[sqs_res])

--- a/tests/features/features/rds.feature
+++ b/tests/features/features/rds.feature
@@ -11,6 +11,7 @@ Feature: ecs_composex.rds
       | use-cases/blog.features.yml | use-cases/rds/rds_basic.yml                   |
       | use-cases/blog.features.yml | use-cases/rds/subnets_override.yml            |
       | use-cases/blog.features.yml | use-cases/rds/rds_cluster_multi_instances.yml |
+      | use-cases/blog.features.yml | use-cases/rds/rds_with_iam_access.yml         |
 
   @rds @lookup
   Scenario Outline: Simple RDS with services

--- a/use-cases/rds/lookup_rds_with_iam_access.yml
+++ b/use-cases/rds/lookup_rds_with_iam_access.yml
@@ -1,0 +1,67 @@
+---
+# RDS Use-case.
+
+version: '3.8'
+x-rds:
+  dbA:
+    MacroParameters:
+      Engine: "aurora-postgresql"
+      EngineVersion: "11.7"
+    Settings:
+      EnvNames:
+        - DBA
+    Services:
+      - name: app01
+        access: RW
+      - name: app03
+        access: RW
+      - name: you-too
+        access: RW
+
+
+  dbB:
+    Properties:
+      Engine: "aurora-postgresql"
+      EngineVersion: "11.7"
+      BackupRetentionPeriod: 1
+      DatabaseName: dbname
+      DeletionProtection: False
+      EnableCloudwatchLogsExports:
+        - audit
+        - general
+      EnableHttpEndpoint: True
+      EnableIAMDatabaseAuthentication: True
+      MasterUsername: dummy
+      MasterUserPassword: dummy
+      Port: 5432
+      StorageEncrypted: True
+      Tags:
+        - Key: Name
+          Value: "dummy-db"
+
+    MacroParameters:
+      IamAccess:
+        Buckets:
+          - x-s3::bucket-01
+          - arn:aws:s3:::sacrificial-lamb/folder/*
+          - bucket-name
+    Settings:
+      EnvNames:
+        - DB_B
+    Services:
+      - name: app01
+        access: RW
+      - name: app03
+        access: RW
+      - name: you-too
+        access: RW
+
+x-s3:
+  bucket-01:
+    Lookup:
+      Tags:
+        - Name: lambda-dev-eu-west-1
+        - costcentre: lambda
+    Services:
+      - name: app03
+        access: RWObjects

--- a/use-cases/rds/rds_with_iam_access.yml
+++ b/use-cases/rds/rds_with_iam_access.yml
@@ -1,0 +1,87 @@
+---
+# RDS Use-case.
+
+version: '3.8'
+x-rds:
+  dbA:
+    MacroParameters:
+      Engine: "aurora-postgresql"
+      EngineVersion: "11.7"
+    Settings:
+      EnvNames:
+        - DBA
+    Services:
+      - name: app01
+        access: RW
+      - name: app03
+        access: RW
+      - name: you-too
+        access: RW
+
+
+  dbB:
+    Properties:
+      Engine: "aurora-postgresql"
+      EngineVersion: "11.7"
+      BackupRetentionPeriod: 1
+      DatabaseName: dbname
+      DeletionProtection: False
+      EnableCloudwatchLogsExports:
+        - audit
+        - general
+      EnableHttpEndpoint: True
+      EnableIAMDatabaseAuthentication: True
+      MasterUsername: dummy
+      MasterUserPassword: dummy
+      Port: 5432
+      StorageEncrypted: True
+      Tags:
+        - Key: Name
+          Value: "dummy-db"
+
+    MacroParameters:
+      IamAccess:
+        Buckets:
+          - x-s3::bucket-01
+          - arn:aws:s3:::sacrificial-lamb/folder/*
+          - bucket-name
+    Settings:
+      EnvNames:
+        - DB_B
+    Services:
+      - name: app01
+        access: RW
+      - name: app03
+        access: RW
+      - name: you-too
+        access: RW
+
+x-s3:
+  bucket-01:
+    Properties:
+      BucketName: bucket-01
+      AccessControl: BucketOwnerFullControl
+      ObjectLockEnabled: True
+      PublicAccessBlockConfiguration:
+          BlockPublicAcls: True
+          BlockPublicPolicy: True
+          IgnorePublicAcls: True
+          RestrictPublicBuckets: False
+      AccelerateConfiguration:
+        AccelerationStatus: Suspended
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      VersioningConfiguration:
+        Status: "Enabled"
+
+    Settings:
+      ExpandRegionToBucket: True
+      ExpandAccountIdToBucket: False
+      EnvNames:
+        - bucket01
+        - BUCKET_ABCD-01
+    Services:
+      - name: app03
+        access: RWObjects


### PR DESCRIPTION
Allows to define IamAccess/Buckets and allows

* Full ARN (auto detects if there is a path there already)
*  Bucket name (and same thing for the path detecion)
* x-s3::bucket-name as defined in x-s3 keys

When using that feature for RDS, the RDS db must be created as part of ComposeX. Otherwise that would mean modifying a DB not part of that app stack which is just not right.
